### PR TITLE
Added CloudFront support

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,11 +80,14 @@ Valid permission options are:
 
 ## Using Cloudfront
 
-To use cloudfront, just enable it in your config/assets.yml by adding a toplevel key:
+To use cloudfront, enable it in your config/assets.yml and set the correct CloudFront domain name:
 
     use_cloudfront: true
+    cloudfront_domain: di8snu3y5lwja.cloudfront.net
 
-For this to work you need to make sure you have the cloudfront enabled via you Amazon acccount page. Go here: http://aws.amazon.com/cloudfront/ and click "Sign Up"
+This will use the CloudFront domainname for your assets instead of serving them from the (slow) S3 bucket.
+
+For this to work you need to make sure you have the CloudFront enabled via you Amazon acccount page. Go here: http://aws.amazon.com/cloudfront/ and click "Sign Up"
 
 
 ## Bugs / Feature Requests

--- a/lib/jammit-s3.rb
+++ b/lib/jammit-s3.rb
@@ -13,9 +13,14 @@ if defined?(Rails)
     class JammitRailtie < Rails::Railtie
       initializer "set asset host and asset id" do
         config.after_initialize do
-          s3_bucket = Jammit.configuration[:s3_bucket]
-          if Jammit.package_assets and s3_bucket.present?
-            ActionController::Base.asset_host = "http://#{Jammit.configuration[:s3_bucket]}.s3.amazonaws.com"
+          if Jammit.configuration[:use_cloudfront] && Jammit.configuration[:cloudfront_domain].present?
+            asset_hostname = "http://#{Jammit.configuration[:cloudfront_domain]}" 
+          else
+            asset_hostname = "http://#{Jammit.configuration[:s3_bucket]}.s3.amazonaws.com"
+          end
+
+          if Jammit.package_assets and asset_hostname.present?
+            ActionController::Base.asset_host = asset_hostname
           end
         end
       end


### PR DESCRIPTION
I just added support for CloudFront. Enable and configure it:

```
use_cloudfront: true
cloudfront_domain: dj83843.cloudfront.net
```

Just push your assets as normal, and you're good to go. 
