### PR TITLE
Allow using assets URL with https

### DIFF
--- a/lib/jammit-s3.rb
+++ b/lib/jammit-s3.rb
@@ -13,10 +13,11 @@ if defined?(Rails)
     class JammitRailtie < Rails::Railtie
       initializer "set asset host and asset id" do
         config.after_initialize do
+          protocol = Jammit.configuration[:ssl] ? "https" : "http"
           if Jammit.configuration[:use_cloudfront] && Jammit.configuration[:cloudfront_domain].present?
-            asset_hostname = "http://#{Jammit.configuration[:cloudfront_domain]}" 
+            asset_hostname = "#{protocol}://#{Jammit.configuration[:cloudfront_domain]}"
           else
-            asset_hostname = "http://#{Jammit.configuration[:s3_bucket]}.s3.amazonaws.com"
+            asset_hostname = "#{protocol}://#{Jammit.configuration[:s3_bucket]}.s3.amazonaws.com"
           end
 
           if Jammit.package_assets and asset_hostname.present?


### PR DESCRIPTION
Allow using assets URL with https when setting ssl: true in jammit configuration.
