### PR TITLE
Fixing a few issues with the Cloudfront invalidation code

### DIFF
--- a/lib/jammit/s3_uploader.rb
+++ b/lib/jammit/s3_uploader.rb
@@ -97,7 +97,7 @@ module Jammit
           log "file has not changed: #{remote_path}"
         end     
       end
-      if Jammit.configuration[:use_cloudfront] && @changed_files.present? 
+      if Jammit.configuration[:use_cloudfront] && !@changed_files.empty? 
         log "invalidating cloudfront cache for changed files"
         invalidate_cache(@changed_files)
       end
@@ -123,7 +123,7 @@ module Jammit
       paths = ""
       files.each do |key|
         log "adding #{key} to list of invalidation requests"
-        paths += "<Path>#{key}</Path>"
+        paths += "<Path>/#{key}</Path>"
       end
       digest = HMAC::SHA1.new(@secret_access_key)
       digest << date = Time.now.utc.strftime("%a, %d %b %Y %H:%M:%S %Z")
@@ -139,7 +139,7 @@ module Jammit
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
       res = http.request(req)
-      log res.code == 201 ? 'Invalidation request succeeded' : "Failed #{res.code}"
+      log res.code == "201" ? 'Invalidation request succeeded' : "Failed #{res.code}"
     end
 
     def log(msg)


### PR DESCRIPTION
1. The files specified for invalidations should have a leading slash.
2. Error code should be quoted
3. .present? doesn't work for some mysterious reason.

Details here- http://docs.amazonwebservices.com/AmazonCloudFront/latest/APIReference/index.html?CreateInvalidation.html
