### PR TITLE
Decrease time on capistrano deployment

### DIFF
--- a/lib/jammit/s3_uploader.rb
+++ b/lib/jammit/s3_uploader.rb
@@ -98,8 +98,6 @@ module Jammit
           else
             log "pushing file to s3: #{remote_path}"
           end
-        else
-          log "file has not changed: #{remote_path}"
         end     
       end
     end


### PR DESCRIPTION
If we had a lot of files in assets deployment time too long with capistrano.
Most time spent on output to console.
