### PR TITLE
jammit-s3 now uses the package_path parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Within your `config/assets.yml`, just add a toplevel key called `s3_bucket` that
 
     s3_bucket: my-awesome-jammit-bucket
 
+The package_path parameter can also be used to create a route folder in your S3 bucket.  This can be useful when pushing assets for different environments.
+  
+    package_path: <%= ENV['RAILS_ENV'] %>
+
 ## Deployment
 
 To deploy your files to s3, just the jammit-s3 command at your project's root.

--- a/lib/jammit/s3_uploader.rb
+++ b/lib/jammit/s3_uploader.rb
@@ -15,6 +15,7 @@ module Jammit
         @access_key_id = options[:access_key_id] || Jammit.configuration[:s3_access_key_id]
         @secret_access_key = options[:secret_access_key] || Jammit.configuration[:s3_secret_access_key]
         @bucket_location = options[:bucket_location] || Jammit.configuration[:s3_bucket_location]
+        @package_path = options[:package_path] || Jammit.configuration[:package_path]
         @cache_control = options[:cache_control] || Jammit.configuration[:s3_cache_control]
         @acl = options[:acl] || Jammit.configuration[:s3_permission]
 
@@ -32,10 +33,10 @@ module Jammit
 
       # add default package path
       if Jammit.gzip_assets
-        globs << "public/#{Jammit.package_path}/**/*.gz"
+        globs << "public/#{@package_path}/**/*.gz"
       else
-        globs << "public/#{Jammit.package_path}/**/*.css"
-        globs << "public/#{Jammit.package_path}/**/*.js"
+        globs << "public/#{@package_path}/**/*.css"
+        globs << "public/#{@package_path}/**/*.js"
       end
 
       # add images
@@ -62,7 +63,7 @@ module Jammit
       log "#{ASSET_ROOT}/#{glob}"
       Dir["#{ASSET_ROOT}/#{glob}"].each do |local_path|
         next if File.directory?(local_path)
-        remote_path = local_path.gsub(/^#{ASSET_ROOT}\/public\//, "")
+        remote_path = local_path.gsub(/^#{ASSET_ROOT}\/public\//, "#{@package_path}")
 
         use_gzip = false
 

--- a/lib/jammit/s3_uploader.rb
+++ b/lib/jammit/s3_uploader.rb
@@ -63,7 +63,7 @@ module Jammit
       log "#{ASSET_ROOT}/#{glob}"
       Dir["#{ASSET_ROOT}/#{glob}"].each do |local_path|
         next if File.directory?(local_path)
-        remote_path = local_path.gsub(/^#{ASSET_ROOT}\/public\//, "#{@package_path}")
+        remote_path = local_path.gsub(/^#{ASSET_ROOT}\/public\//, "#{@package_path}/")
 
         use_gzip = false
 

--- a/lib/jammit/s3_uploader.rb
+++ b/lib/jammit/s3_uploader.rb
@@ -63,7 +63,7 @@ module Jammit
       log "#{ASSET_ROOT}/#{glob}"
       Dir["#{ASSET_ROOT}/#{glob}"].each do |local_path|
         next if File.directory?(local_path)
-        remote_path = local_path.gsub(/^#{ASSET_ROOT}\/public\//, "#{@package_path}/")
+        remote_path = local_path.gsub(/^#{ASSET_ROOT}\/public\/(#{@package_path}\/)?/, "#{@package_path}/")
 
         use_gzip = false
 


### PR DESCRIPTION
We had an issue where we need to store assets for distribution on cloudfront.  We wanted each environment to have its own route folder on the s3 bucket.  Jammit-s3 was currently not using the package_path parameter but it seems logical that it should.
