### PR TITLE
Jon/load cloudfront config and add multiple dists for expirations

### DIFF
--- a/lib/jammit-s3.rb
+++ b/lib/jammit-s3.rb
@@ -6,5 +6,13 @@ module Jammit
   def self.upload_to_s3!(options = {})
     S3Uploader.new(options).upload
   end
-end
 
+  def self.cloudfront_configuration(env = nil)
+    @cloudfront_configuration ||=
+      begin
+        rails_env = defined?(Rails) ? Rails.env : ENV['RAILS_ENV']
+        cloudfront_config_path = File.join(ASSET_ROOT, 'config', 'cloudfront.yml')
+        cloudfront_config = symbolize_keys(YAML.load(File.read(cloudfront_config_path))[rails_env])
+      end
+  end
+end

--- a/lib/jammit-s3.rb
+++ b/lib/jammit-s3.rb
@@ -8,37 +8,3 @@ module Jammit
   end
 end
 
-if defined?(Rails)
-  module Jammit
-    class JammitRailtie < Rails::Railtie
-      initializer "set asset host and asset id" do
-        config.before_initialize do
-          if Jammit.configuration[:use_cloudfront] && Jammit.configuration[:cloudfront_cname].present? && Jammit.configuration[:cloudfront_domain].present?
-            asset_hostname = Jammit.configuration[:cloudfront_cname]
-            asset_hostname_ssl = Jammit.configuration[:cloudfront_domain]
-          elsif Jammit.configuration[:use_cloudfront] && Jammit.configuration[:cloudfront_domain].present?
-            asset_hostname = asset_hostname_ssl = Jammit.configuration[:cloudfront_domain]            
-          else
-            asset_hostname = asset_hostname_ssl = "#{Jammit.configuration[:s3_bucket]}.s3.amazonaws.com"
-          end
-
-          if Jammit.package_assets and asset_hostname.present?
-            puts "Initializing Cloudfront"                      
-            ActionController::Base.asset_host = Proc.new do |source, request|
-              if Jammit.configuration.has_key?(:ssl)
-                protocol = Jammit.configuration[:ssl] ? "https://" : "http://"
-              else
-                protocol = request.protocol
-              end
-              if request.protocol == "https://"
-                "#{protocol}#{asset_hostname_ssl}"
-              else 
-                "#{protocol}#{asset_hostname}"  
-              end              
-            end
-          end
-        end
-      end
-    end
-  end
-end

--- a/lib/jammit/s3_command_line.rb
+++ b/lib/jammit/s3_command_line.rb
@@ -16,7 +16,7 @@ module Jammit
 
     protected
       def ensure_s3_configuration
-        bucket_name = Jammit.configuration[:s3_bucket]
+        bucket_name = Jammit.cloudfront_configuration[:s3_bucket]
         unless bucket_name.is_a?(String) && bucket_name.length > 0
           puts "\nA valid s3_bucket name is required."
           puts "Please add one to your Jammit config (config/assets.yml):\n\n"
@@ -24,13 +24,13 @@ module Jammit
           exit(1)
         end
 
-        access_key_id = Jammit.configuration[:s3_access_key_id]
+        access_key_id = Jammit.cloudfront_configuration[:s3_access_key_id]
         unless access_key_id.is_a?(String) && access_key_id.length > 0
           puts "access_key_id: '#{access_key_id}' is not valid"
           exit(1)
         end
 
-        secret_access_key = Jammit.configuration[:s3_secret_access_key]
+        secret_access_key = Jammit.cloudfront_configuration[:s3_secret_access_key]
         unless secret_access_key.is_a?(String) && secret_access_key.length > 0
           puts "secret_access_key: '#{secret_access_key}' is not valid"
           exit(1)


### PR DESCRIPTION
He hecho los siguientes cambios en la gema:
- quito la configuracion del asset_host desde la gema, creo que esto ha de definirse en las aplicaciones según las necesidades que pueda tener.
- la configuración relacionada con la gema se carga desde ROOT/config/cloudfront.yml, uso algunas constantes que ya usa Jammit para esto.
- Adaptar la gema para usar esta nueva configuración
- Añadir soporte para expirar contra distintas distribuciones de cloudfront.
